### PR TITLE
fix: validate arguments of `CopyTo`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
+++ b/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
@@ -103,18 +103,23 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="Stream.CopyTo(Stream, int)" />
 #if NETSTANDARD2_0 || NET462
-	public new virtual void CopyTo(Stream destination, int bufferSize)
-		=> _stream.CopyTo(destination, bufferSize);
+	    public new virtual void CopyTo(Stream destination, int bufferSize)
 #else
         public override void CopyTo(Stream destination, int bufferSize)
-            => _stream.CopyTo(destination, bufferSize);
 #endif
+        {
+            ValidateCopyToArguments(this, destination, bufferSize);
+            _stream.CopyTo(destination, bufferSize);
+        }
 
         /// <inheritdoc cref="Stream.CopyToAsync(Stream, int, CancellationToken)" />
         public override Task CopyToAsync(Stream destination,
             int bufferSize,
             CancellationToken cancellationToken)
-            => _stream.CopyToAsync(destination, bufferSize, cancellationToken);
+        {
+            ValidateCopyToArguments(this, destination, bufferSize);
+            return _stream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
 
         /// <inheritdoc cref="Stream.EndRead(IAsyncResult)" />
         public override int EndRead(IAsyncResult asyncResult)
@@ -141,9 +146,9 @@ namespace System.IO.Abstractions
             => _stream.Read(buffer, offset, count);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Stream.Read(Span{byte})" />
-	public override int Read(Span<byte> buffer)
-		=> _stream.Read(buffer);
+	    /// <inheritdoc cref="Stream.Read(Span{byte})" />
+	    public override int Read(Span<byte> buffer)
+		    => _stream.Read(buffer);
 #endif
 
         /// <inheritdoc cref="Stream.ReadAsync(byte[], int, int, CancellationToken)" />
@@ -154,10 +159,10 @@ namespace System.IO.Abstractions
             => _stream.ReadAsync(buffer, offset, count, cancellationToken);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Stream.ReadAsync(Memory{byte}, CancellationToken)" />
-	public override ValueTask<int> ReadAsync(Memory<byte> buffer,
-	                                         CancellationToken cancellationToken = new())
-		=> _stream.ReadAsync(buffer, cancellationToken);
+	    /// <inheritdoc cref="Stream.ReadAsync(Memory{byte}, CancellationToken)" />
+	    public override ValueTask<int> ReadAsync(Memory<byte> buffer,
+	                                             CancellationToken cancellationToken = new())
+		    => _stream.ReadAsync(buffer, cancellationToken);
 #endif
 
         /// <inheritdoc cref="Stream.ReadByte()" />
@@ -181,9 +186,9 @@ namespace System.IO.Abstractions
             => _stream.Write(buffer, offset, count);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Stream.Write(ReadOnlySpan{byte})" />
-	public override void Write(ReadOnlySpan<byte> buffer)
-		=> _stream.Write(buffer);
+	    /// <inheritdoc cref="Stream.Write(ReadOnlySpan{byte})" />
+	    public override void Write(ReadOnlySpan<byte> buffer)
+		    => _stream.Write(buffer);
 #endif
 
         /// <inheritdoc cref="Stream.WriteAsync(byte[], int, int, CancellationToken)" />
@@ -194,10 +199,10 @@ namespace System.IO.Abstractions
             => _stream.WriteAsync(buffer, offset, count, cancellationToken);
 
 #if FEATURE_SPAN
-	/// <inheritdoc cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)" />
-	public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer,
-	                                     CancellationToken cancellationToken = new())
-		=> _stream.WriteAsync(buffer, cancellationToken);
+	    /// <inheritdoc cref="Stream.WriteAsync(ReadOnlyMemory{byte}, CancellationToken)" />
+	    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer,
+	                                         CancellationToken cancellationToken = new())
+		    => _stream.WriteAsync(buffer, cancellationToken);
 #endif
 
         /// <inheritdoc cref="Stream.WriteByte(byte)" />
@@ -219,6 +224,39 @@ namespace System.IO.Abstractions
         public static explicit operator FileStream(FileSystemStream fsStream)
         {
             return (FileStream) fsStream._stream;
+        }
+
+        private static void ValidateCopyToArguments(Stream source, Stream destination, int bufferSize)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination), "Destination cannot be null.");
+            }
+
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size must be greater than zero.");
+            }
+
+            if (!destination.CanWrite)
+            {
+                if (destination.CanRead)
+                {
+                    throw new NotSupportedException("Stream does not support writing.");
+                }
+
+                throw new ObjectDisposedException("Cannot access a closed Stream.");
+            }
+            
+            if (!source.CanRead)
+            {
+                if (source.CanWrite)
+                {
+                    throw new NotSupportedException("Stream does not support reading.");
+                }
+
+                throw new ObjectDisposedException("Cannot access a closed Stream.");
+            }
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -293,5 +293,85 @@
             Assert.That(result.Length, Is.Zero);
             Assert.That(result.IsAsync, Is.True);
         }
+        
+        [Test]
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void MockFileStream_WhenBufferSizeIsNotPositive_ShouldThrowArgumentNullException(int bufferSize)
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("foo.txt", "");
+            fileSystem.File.WriteAllText("bar.txt", "");
+            using var source = fileSystem.FileInfo.New(@"foo.txt").OpenRead();
+            using var destination = fileSystem.FileInfo.New(@"bar.txt").OpenWrite();
+            
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => 
+                await source.CopyToAsync(destination, bufferSize));
+        }
+        
+        [Test]
+        public void MockFileStream_WhenDestinationIsClosed_ShouldThrowObjectDisposedException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("foo.txt", "");
+            fileSystem.File.WriteAllText("bar.txt", "");
+            using var source = fileSystem.FileInfo.New(@"foo.txt").OpenRead();
+            using var destination = fileSystem.FileInfo.New(@"bar.txt").OpenWrite();
+            destination.Close();
+            
+            Assert.ThrowsAsync<ObjectDisposedException>(async () => 
+                await source.CopyToAsync(destination));
+        }
+        
+        [Test]
+        public void MockFileStream_WhenDestinationIsNull_ShouldThrowArgumentNullException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("foo.txt", "");
+            using var source = fileSystem.FileInfo.New(@"foo.txt").OpenRead();
+            
+            Assert.ThrowsAsync<ArgumentNullException>(async () => 
+                await source.CopyToAsync(null));
+        }
+        
+        [Test]
+        public void MockFileStream_WhenDestinationIsReadOnly_ShouldThrowNotSupportedException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("foo.txt", "");
+            fileSystem.File.WriteAllText("bar.txt", "");
+            using var source = fileSystem.FileInfo.New(@"foo.txt").OpenRead();
+            using var destination = fileSystem.FileInfo.New(@"bar.txt").OpenRead();
+            
+            Assert.ThrowsAsync<NotSupportedException>(async () => 
+                await source.CopyToAsync(destination));
+        }
+
+        [Test]
+        public void MockFileStream_WhenSourceIsClosed_ShouldThrowObjectDisposedException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("foo.txt", "");
+            fileSystem.File.WriteAllText("bar.txt", "");
+            using var source = fileSystem.FileInfo.New(@"foo.txt").OpenRead();
+            using var destination = fileSystem.FileInfo.New(@"bar.txt").OpenWrite();
+            source.Close();
+            
+            Assert.ThrowsAsync<ObjectDisposedException>(async () => 
+                await source.CopyToAsync(destination));
+        }
+
+        [Test]
+        public void MockFileStream_WhenSourceIsWriteOnly_ShouldThrowNotSupportedException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("foo.txt", "");
+            fileSystem.File.WriteAllText("bar.txt", "");
+            using var source = fileSystem.FileInfo.New(@"foo.txt").OpenWrite();
+            using var destination = fileSystem.FileInfo.New(@"bar.txt").OpenWrite();
+            
+            Assert.ThrowsAsync<NotSupportedException>(async () => 
+                await source.CopyToAsync(destination));
+        }
     }
 }


### PR DESCRIPTION
Fixes #1156